### PR TITLE
Create the Facebook schedule post function for the front-end

### DIFF
--- a/controllers/api.js
+++ b/controllers/api.js
@@ -26,6 +26,8 @@ var querystring = require('querystring');
 
 var secrets = require('../config/secrets');
 
+var SCHEDULER_SERVER = "http://default-environment-wrvkfm7bup.elasticbeanstalk.com";
+
 /**
  * GET /api
  * List of API examples.
@@ -177,6 +179,43 @@ exports.postFeedFacebook = function(req, res, next) {
       friends: results.getMyFriends
     });
   });
+};
+
+/**
+ *  schedule a facebook post using our manual server
+ *  actionTime, is the time when the post should be sent out to a Facebook Page, e.g. 5 minutes, 5 secs, 2 days, or timestamp
+ *  pageAccessToken, facebook page access token.
+ *  message, message to be sent out
+ *  applicationId, application id of a campaign
+ *  callback, response callback function
+ *  Note that: the page access token could be expired when the action time is set after the expired token time. 
+ **/
+exports.scheduleFacebookPost = function(actionTime, pageAccessToken, message, pageId, applicationId, callback) {
+    var options = {
+        method: 'POST',
+        url: SCHEDULER_SERVER + '/schedule', 
+        body:  JSON.stringify({
+            applicationId : applicationId,
+            pageId: pageId,
+            actionTime: actionTime,
+            pageAccessToken: pageAccessToken,
+            message: message
+        }),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+    };
+                      
+    request(options, function(error, response, finalBody) {
+          if (error) {
+              console.error("Unable to update the post ID to application collection using lambda service.");
+              console.error(error);
+          } else {
+              console.log(finalBody);
+          }
+          
+          callback(error, finalBody);
+    });
 };
 
 


### PR DESCRIPTION
Created the scheduleFacebookPost function by passing the following parameters:

```json
{
   "actionTime" : "5 seconds",
   "accessToken" : "CAACaKDjdeZC4BACZAAfqRtxPH4zsJuWdyHKQR2TKpgVZAQakzSU4d40ALSWeukwZAR3Tn7d4c6yPeIXQhZBrgokLqznAYJa54OtKF3r3CrePUJVstLB3Qg4LEcOp4rolh58ZBxOY5LIbPWZA4ZBnE2ewM8IZA1zC22y0mhGi6ySaOs1LRnRoIA8L3I3oHyTJlu4YZD",
   "message": "what are you doing 27?",
   "pageId": "203205743360084",
   "applicationId": "ericso_test_application_100"
}
```

schedule a facebook post using our manual server
 - actionTime, is the time when the post should be sent out to a Facebook Page, e.g. 5 minutes, 5 secs, 2 days, or timestamp
 - pageAccessToken, facebook page access token.
 - message, message to be sent out
 - applicationId, application id of a campaign
 - callback, response callback function
 
- Note that: the page access token could be expired when the action time is set after the expired token time. 
 